### PR TITLE
Use `delta_incr` for delta increments

### DIFF
--- a/lib/stagger/aggregator.rb
+++ b/lib/stagger/aggregator.rb
@@ -33,7 +33,12 @@ module Stagger
     end
 
     def delta(key, value, tags = {})
-      incr(key, @deltas[to_key(key, tags)].delta(value))
+      k = to_key(key, tags)
+      v = @deltas[k].delta(value)
+
+      if v
+        @counters[k] += value
+      end
     end
     alias :delta_incr :delta
 


### PR DESCRIPTION
We don't want to use the `incr` method for deltas since delta values may be zeroes. The incr method ignores values if not > 0. While this makes sense for counters, it does not make sense for delta values since delta's may be 0.

Delta's use counters behind the scenes but increment only once per cycle, unlike counters. This leads to some misdirection.

@mdpye